### PR TITLE
Automate to update export EDN files #3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: build
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: '0 1 * * *'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: v1-dependencies-${{ hashFiles('project.clj') }}
+      - name: Build exports
+        run: |
+          lein run
+          ls -ltr exports
+      - name: Commit and push if changed
+        run: |
+          git diff
+          git config --global user.email "exports-bot@example.com"
+          git config --global user.name "EXPORTS-bot"
+          git add -A
+          git commit -m "Updated exports" || exit 0
+          git push

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # clojuredocs-export-edn
 
+![build](https://github.com/clojure-emacs/clojuredocs-export-edn/workflows/build/badge.svg)
 [![Dependencies Status](https://versions.deps.co/clojure-emacs/clojuredocs-export-edn/status.svg)](https://versions.deps.co/clojure-emacs/clojuredocs-export-edn)
 
 A simple tool that converts [ClojureDocs](https://clojuredocs.org)'s


### PR DESCRIPTION
I've tested auto commiting by GitHub Actions in the following action.
https://github.com/clojure-emacs/clojuredocs-export-edn/actions/runs/455148022

![image](https://user-images.githubusercontent.com/6941/103426174-e329b280-4bfa-11eb-9c0d-1b73b7f922e0.png)